### PR TITLE
Fix bot startup import errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -6,8 +6,15 @@ from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.constants import ParseMode
 from telegram.ext import Application, CommandHandler, CallbackQueryHandler, ContextTypes
 
-from .economy_v1 import load_player, list_catalog, buy_car, set_current_car, list_tracks, set_current_track
-from .game_api import run_player_race
+from economy_v1 import (
+    load_player,
+    list_catalog,
+    buy_car,
+    set_current_car,
+    list_tracks,
+    set_current_track,
+)
+from game_api import run_player_race
 
 DATA_DIR = Path(os.getenv("GAME_DATA_DIR", "./data"))
 BOT_TOKEN = os.getenv("BOT_TOKEN")
@@ -115,7 +122,7 @@ async def driver(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if not p.driver_json:
         await send_html(update, "Профиль пилота появится после первой гонки (<code>/race</code>).")
         return
-    from .models_v2 import DriverProfile
+    from models_v2 import DriverProfile
     d = DriverProfile.from_json(p.driver_json)
     skills = asdict(d)
     lines = ["<b>Навыки пилота:</b>"]
@@ -213,7 +220,7 @@ def build_app() -> Application:
     app.add_handler(CommandHandler("settrack", settrack_cmd))
     app.add_handler(CommandHandler("race", race))
     app.add_handler(CallbackQueryHandler(on_callback))
-    from . import bot_lobby
+    import bot_lobby
     bot_lobby.setup(app)
     app.add_error_handler(error_handler)
     return app

--- a/bot_lobby.py
+++ b/bot_lobby.py
@@ -1,9 +1,9 @@
 from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes
 
-from .economy_v1 import load_player
-from .lobby import create_lobby, join_lobby, leave_lobby, start_lobby_race
-from .bot import esc, _uid, _uname, send_html
+from economy_v1 import load_player
+from lobby import create_lobby, join_lobby, leave_lobby, start_lobby_race
+from bot import esc, _uid, _uname, send_html
 
 
 async def lobby_create_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/game_api.py
+++ b/game_api.py
@@ -2,8 +2,8 @@ import os, json
 from typing import Optional, Dict, Callable
 from pathlib import Path
 from datetime import date
-from .models_v2 import Car, Track, TrackSegment, DriverProfile, run_race
-from .economy_v1 import (
+from models_v2 import Car, Track, TrackSegment, DriverProfile, run_race
+from economy_v1 import (
     load_player,
     save_player,
     list_catalog,

--- a/lobby.py
+++ b/lobby.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import Dict, List
-from .game_api import run_player_race
+
+from game_api import run_player_race
 
 # Простые лобби в памяти процесса
 LOBBIES: Dict[str, Dict] = {}

--- a/models_v2.py
+++ b/models_v2.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, asdict
 from typing import List, Optional, Dict, Tuple, Callable
 import random, json
 
-from .config_v2 import (
+from config_v2 import (
     USE_ROLLING_RESISTANCE, C_RR, K_LAT, ERROR_RATE_BASE, TIME_PENALTY_RANGE, DT_MAX,
     XP_PER_KM, PROGRESSION
 )

--- a/run.py
+++ b/run.py
@@ -1,3 +1,9 @@
-from scripts.run_bot import main
+"""Entry point for launching the Telegram racing bot."""
+
+# The project used to expose a ``scripts.run_bot`` module but the directory was
+# removed while the stub remained.  Import the main function directly from the
+# ``bot`` module instead so the bot can be started via ``python run.py``.
+
+from bot import main
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- import main directly from bot module in run.py
- replace package-relative imports with absolute imports across bot modules
- update entry points to ensure bot can launch without missing package errors

## Testing
- `pytest`
- `python run.py` *(fails: Не задан BOT_TOKEN. Создай .env или экспортируй переменную окружения.)*

------
https://chatgpt.com/codex/tasks/task_b_689cb8c49ce8832eac5dde21aac86ab7