### PR TITLE
Restore keyboard helpers and reinstate tests

### DIFF
--- a/bot_kb.py
+++ b/bot_kb.py
@@ -1,0 +1,54 @@
+from typing import Dict
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from economy_v1 import list_catalog, list_tracks
+
+
+def fmt_money(v: int) -> str:
+    """Format integer value with spaces for thousands."""
+    return f"{v:,}".replace(",", " ")
+
+
+def main_menu_kb() -> InlineKeyboardMarkup:
+    """Main menu with quick navigation links."""
+    return InlineKeyboardMarkup([
+        [
+            InlineKeyboardButton("Справка", callback_data="nav:help"),
+            InlineKeyboardButton("Гараж", callback_data="nav:garage"),
+        ],
+        [
+            InlineKeyboardButton("Каталог", callback_data="nav:catalog"),
+            InlineKeyboardButton("Трассы", callback_data="nav:tracks"),
+        ],
+    ])
+
+
+def garage_kb(p) -> InlineKeyboardMarkup:
+    """Keyboard listing player's cars with upgrade buttons."""
+    cat = list_catalog()
+    rows = []
+    for cid in p.garage:
+        name = cat["cars"].get(cid, {}).get("name", cid)
+        rows.append([InlineKeyboardButton(name, callback_data=f"upgrades:{cid}")])
+    rows.append([InlineKeyboardButton("Обновить", callback_data="nav:garage")])
+    return InlineKeyboardMarkup(rows)
+
+
+def catalog_kb(cat: Dict) -> InlineKeyboardMarkup:
+    """Keyboard with catalog cars and buy buttons."""
+    rows = []
+    cars = sorted(cat["cars"].items(), key=lambda kv: kv[1]["price"])[:12]
+    for cid, item in cars:
+        label = f"{item['name']} — {fmt_money(item['price'])}"
+        rows.append([InlineKeyboardButton(label, callback_data=f"buy:{cid}")])
+    rows.append([InlineKeyboardButton("Обновить", callback_data="nav:catalog")])
+    return InlineKeyboardMarkup(rows)
+
+
+def tracks_kb() -> InlineKeyboardMarkup:
+    """Keyboard listing available tracks."""
+    rows = []
+    for tid, name in list(list_tracks().items())[:12]:
+        rows.append([InlineKeyboardButton(f"{name}", callback_data=f"settrack:{tid}")])
+    rows.append([InlineKeyboardButton("Обновить", callback_data="nav:tracks")])
+    return InlineKeyboardMarkup(rows)

--- a/models_v2.py
+++ b/models_v2.py
@@ -221,6 +221,7 @@ class RaceEngine:
                 "type": "segment_tick",
                 "segment": seg_before.name,
                 "time_s": self.state.total_time,
+                "speed": self.state.speed * 3.6,
             })
             self._last_seg_evt_time = self.state.total_time
         if self.state.segment_distance >= seg_before.length:
@@ -247,6 +248,7 @@ class RaceEngine:
                     "type": "segment_change",
                     "segment": self.current_segment.name,
                     "time_s": self.state.total_time,
+                    "speed": self.state.speed * 3.6,
                 })
             # новая секция – сбрасываем таймер сегмента
             self._last_seg_evt_time = self.state.total_time

--- a/tests/test_garage_buttons.py
+++ b/tests/test_garage_buttons.py
@@ -1,0 +1,18 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from bot_kb import garage_kb
+from economy_v1 import list_catalog
+
+
+def test_garage_keyboard_lists_cars():
+    class P:
+        garage = ["lada_2107", "bugatti"]
+    kb = garage_kb(P())
+    cat = list_catalog()
+    labels = [btn.text for row in kb.inline_keyboard for btn in row]
+    # ensure refresh button
+    assert "Обновить" in labels
+    for cid in P.garage:
+        name = cat["cars"][cid]["name"]
+        assert name in labels

--- a/tests/test_lobby.py
+++ b/tests/test_lobby.py
@@ -1,0 +1,26 @@
+import os, sys, pytest
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import lobby
+
+
+def test_lobby_create_join_start(monkeypatch):
+    lobby.reset_lobbies()
+    lid = lobby.create_lobby("track1")
+    lobby.join_lobby(lid, "u1", "A")
+    lobby.join_lobby(lid, "u2", "B")
+
+    def fake_run(uid, name, track_id=None, laps=1):
+        return {"time_s": 1.23, "incidents": 0, "reward": 0}
+
+    monkeypatch.setattr(lobby, "run_player_race", fake_run)
+    res = lobby.start_lobby_race(lid, laps=1)
+    assert {r["user_id"] for r in res} == {"u1", "u2"}
+
+
+def test_lobby_requires_two_players():
+    lobby.reset_lobbies()
+    lid = lobby.create_lobby("track1")
+    lobby.join_lobby(lid, "u1", "A")
+    with pytest.raises(RuntimeError):
+        lobby.start_lobby_race(lid)

--- a/tests/test_main_menu_buttons.py
+++ b/tests/test_main_menu_buttons.py
@@ -1,0 +1,13 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from bot_kb import main_menu_kb
+
+
+def test_main_menu_has_buttons():
+    kb = main_menu_kb()
+    labels = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "Справка" in labels
+    assert "Гараж" in labels
+    assert "Каталог" in labels
+    assert "Трассы" in labels

--- a/tests/test_race_progress.py
+++ b/tests/test_race_progress.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from models_v2 import Car, Track, TrackSegment, RaceEngine
+
+
+def test_race_events_include_speed():
+    car = Car(id="c", name="Car", power=100, mass=1000, cd=0.35, area=2.0, tire_grip=1.0)
+    track = Track(
+        "t",
+        "Test",
+        [
+            TrackSegment("s1", "straight", 100, 1, 1, 1, 1),
+            TrackSegment("s2", "straight", 100, 1, 1, 1, 1),
+        ],
+    )
+    speeds = []
+
+    def on_evt(evt):
+        if evt["type"] in ("segment_tick", "segment_change"):
+            speeds.append(evt["speed"])
+
+    eng = RaceEngine(car, track, laps=1, on_event=on_evt)
+    eng.run(dt=0.1)
+    assert speeds and all(isinstance(s, float) for s in speeds)


### PR DESCRIPTION
## Summary
- Move keyboard-building utilities into a dedicated `bot_kb.py` module and import them from the bot
- Reintroduce separated test suite covering garage buttons, lobby races, and race events
- Expand the main menu with catalog and track shortcuts, with tests verifying button presence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cc57dae8c832ea8a127c51940739f