### PR TITLE
Add premium support and vibrant race logs

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -169,20 +169,38 @@ async def race(update: Update, context: ContextTypes.DEFAULT_TYPE):
         msg = None
         if etype == "penalty":
             sev = esc(evt.get("severity", "minor"))
-            msg = f"⚠️ Пенальти ({sev}): +{evt['delta_s']:.2f}s на {esc(evt['segment'])} (нагрузка {evt['load']:.2f})"
+            msg = (
+                f"🚫 <b>Пенальти ({sev})</b>\n"
+                f"⏱ <i>+{evt['delta_s']:.2f}s</i> на {esc(evt['segment'])}\n"
+                f"📉 Нагрузка: {evt['load']:.2f}"
+            )
         elif etype == "segment_tick":
-            msg = f"⏱ {evt['time_s']:.2f}s, {evt['speed']:.1f} км/ч"
+            msg = (
+                f"🏎️ <b>Круг {evt['lap']}/{evt['laps']}</b>\n"
+                f"📍 <b>{esc(evt['segment'])}</b> <i>(ID {evt['segment_id']})</i>\n"
+                f"⚡️ <code>{evt['speed']:.1f} км/ч</code>\n"
+                f"⏰ <code>{evt['time_s']:.1f} сек</code>\n"
+                f"📊 <code>{evt['distance']:.0f}/{evt['segment_length']:.0f} м</code>"
+            )
             asyncio.run_coroutine_threadsafe(send_html(update, msg), loop)
             time.sleep(20.0)
             return
         elif etype == "segment_change":
-            msg = f"➡️ {esc(evt['segment'])}: {evt['time_s']:.2f}s, {evt['speed']:.1f} км/ч"
+            msg = (
+                f"🔁 <b>Новый участок: {esc(evt['segment'])}</b>\n"
+                f"⚡️ <code>{evt['speed']:.1f} км/ч</code>\n"
+                f"⏰ <code>{evt['time_s']:.1f} сек</code>"
+            )
         elif etype == "lap_complete":
-            msg = f"🏁 Круг {evt['lap']} — {evt['time_s']:.2f}s"
+            msg = f"🏁 <b>Круг {evt['lap']} завершён</b> — <code>{evt['time_s']:.2f}s</code>"
         elif etype == "race_complete":
-            msg = f"🏁 Гонка — {evt['time_s']:.2f}s, инцидентов: {evt.get('incidents',0)}"
+            msg = (
+                f"🏁 <b>Гонка завершена!</b>\n"
+                f"⏱ <code>{evt['time_s']:.2f}s</code>\n"
+                f"⚠️ Инцидентов: <code>{evt.get('incidents',0)}</code>"
+            )
         elif etype == "skill_up":
-            msg = f"📈 {esc(evt['skill'])} +{evt['delta']:.2f} → {evt['new']:.1f}"
+            msg = f"📈 <b>{esc(evt['skill'])}</b> +{evt['delta']:.2f} → {evt['new']:.1f}"
         if msg:
             asyncio.run_coroutine_threadsafe(send_html(update, msg), loop)
 
@@ -193,7 +211,10 @@ async def race(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await send_html(update, f"❌ {esc(e)}")
         return
 
-    await send_html(update, f"<b>Итог:</b> время {result['time_s']:.2f}s, инцидентов {result['incidents']}, награда {fmt_money(result['reward'])}")
+    await send_html(
+        update,
+        f"🏆 <b>Итог:</b> ⏱ {result['time_s']:.2f}s | ⚠️ {result['incidents']} | 💰 {fmt_money(result['reward'])}"
+    )
 
 async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query

--- a/data/premium.txt
+++ b/data/premium.txt
@@ -1,0 +1,1 @@
+# Add Telegram user IDs here, one per line, to grant premium status.

--- a/economy_v1.py
+++ b/economy_v1.py
@@ -213,9 +213,9 @@ def set_current_track(p: Player, track_id: str) -> str:
     return f"🏁 Текущая трасса: {tracks[track_id]} (`{track_id}`)"
 
 def payout_for_race(car_tier: str, laps: int, incidents: int, clean: bool) -> int:
+    """Compute race payout without penalizing incidents."""
     base = RACE_BASE_REWARD.get(car_tier, 300) * max(1, laps)
     mult = 1.0 + (CLEAN_BONUS if clean else 0.0)
-    mult *= max(0.5, 1.0 - PENALTY_TAX * max(0, incidents))
     return max(0, int(base * mult))
 
 def reward_player(p: Player, amount: int) -> None:

--- a/game_api.py
+++ b/game_api.py
@@ -17,6 +17,7 @@ from economy_v1 import (
     upgrade_status,
     list_upgrade_parts,
 )
+from premium import is_premium
 
 DATA_DIR = Path(os.getenv("GAME_DATA_DIR", "./data"))
 MAX_RACES_PER_DAY = 5
@@ -49,6 +50,8 @@ def save_driver(p, d: DriverProfile):
 
 
 def _check_daily_limit(p):
+    if is_premium(p.user_id):
+        return
     today = date.today().isoformat()
     if p.last_race_day != today:
         p.last_race_day = today

--- a/models_v2.py
+++ b/models_v2.py
@@ -220,6 +220,11 @@ class RaceEngine:
             self._notify({
                 "type": "segment_tick",
                 "segment": seg_before.name,
+                "segment_id": self.state.current_segment_idx + 1,
+                "segment_length": seg_before.length,
+                "distance": self.state.segment_distance,
+                "lap": self.state.current_lap,
+                "laps": self.laps,
                 "time_s": self.state.total_time,
                 "speed": self.state.speed * 3.6,
             })
@@ -247,6 +252,9 @@ class RaceEngine:
                 self._notify({
                     "type": "segment_change",
                     "segment": self.current_segment.name,
+                    "segment_id": self.state.current_segment_idx + 1,
+                    "lap": self.state.current_lap,
+                    "laps": self.laps,
                     "time_s": self.state.total_time,
                     "speed": self.state.speed * 3.6,
                 })

--- a/premium.py
+++ b/premium.py
@@ -1,0 +1,13 @@
+import os
+from pathlib import Path
+
+DATA_DIR = Path(os.getenv("GAME_DATA_DIR", "./data"))
+PREMIUM_FILE = DATA_DIR / "premium.txt"
+
+def is_premium(user_id: str) -> bool:
+    try:
+        content = PREMIUM_FILE.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return False
+    ids = {line.strip() for line in content.splitlines() if line.strip()}
+    return str(user_id) in ids

--- a/tests/test_lobby.py
+++ b/tests/test_lobby.py
@@ -2,25 +2,94 @@ import os, sys, pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import lobby
+import bot_lobby
+import asyncio
 
 
 def test_lobby_create_join_start(monkeypatch):
     lobby.reset_lobbies()
     lid = lobby.create_lobby("track1")
-    lobby.join_lobby(lid, "u1", "A")
-    lobby.join_lobby(lid, "u2", "B")
+    lobby.join_lobby(lid, "u1", "A", chat_id="c1", mass=1000, power=100)
+    lobby.join_lobby(lid, "u2", "B", chat_id="c1", mass=900, power=110)
 
-    def fake_run(uid, name, track_id=None, laps=1):
+    events = []
+
+    def fake_run(uid, name, track_id=None, laps=1, on_event=None):
+        if on_event:
+            on_event({"type": "penalty", "segment": "S", "delta_s": 1.0})
+            on_event(
+                {
+                    "type": "segment_tick",
+                    "segment": "S",
+                    "segment_id": 1,
+                    "segment_length": 100,
+                    "distance": 50,
+                    "lap": 1,
+                    "laps": 1,
+                    "time_s": 5.0,
+                    "speed": 50.0,
+                }
+            )
         return {"time_s": 1.23, "incidents": 0, "reward": 0}
 
     monkeypatch.setattr(lobby, "run_player_race", fake_run)
-    res = lobby.start_lobby_race(lid, laps=1)
+    res = lobby.start_lobby_race(lid, laps=1, on_event=events.append)
     assert {r["user_id"] for r in res} == {"u1", "u2"}
+    penalties = [e for e in events if e["type"] == "penalty"]
+    assert len(penalties) == 2
+    ticks = [e for e in events if e["type"] == "segment_tick"]
+    assert len(ticks) == 2
 
 
 def test_lobby_requires_two_players():
     lobby.reset_lobbies()
     lid = lobby.create_lobby("track1")
-    lobby.join_lobby(lid, "u1", "A")
+    lobby.join_lobby(lid, "u1", "A", chat_id="c1", mass=1000, power=100)
     with pytest.raises(RuntimeError):
         lobby.start_lobby_race(lid)
+
+
+def test_lobby_max_players():
+    lobby.reset_lobbies()
+    lid = lobby.create_lobby("track1")
+    for i in range(8):
+        lobby.join_lobby(lid, f"u{i}", f"P{i}", chat_id=f"c{i}", mass=900 + i, power=100 + i)
+    with pytest.raises(RuntimeError):
+        lobby.join_lobby(lid, "u8", "P8", chat_id="c8", mass=950, power=120)
+
+
+def test_group_start_messages(monkeypatch):
+    lobby.reset_lobbies()
+    lid = lobby.create_lobby("track1")
+    lobby.join_lobby(lid, "u1", "A", chat_id="10", mass=1000, power=100)
+    lobby.join_lobby(lid, "u2", "B", chat_id="10", mass=900, power=110)
+
+    def fake_start_lobby_race(_):
+        return [
+            {"user_id": "u1", "name": "A", "result": {"time_s": 1.0}},
+            {"user_id": "u2", "name": "B", "result": {"time_s": 2.0}},
+        ]
+
+    monkeypatch.setattr(bot_lobby, "start_lobby_race", fake_start_lobby_race)
+
+    sent = []
+
+    class FakeBot:
+        async def send_message(self, chat_id, text, parse_mode=None):
+            sent.append((chat_id, text))
+
+    class FakeContext:
+        def __init__(self):
+            self.args = [lid]
+            self.bot = FakeBot()
+
+    class FakeUpdate:
+        pass
+
+    asyncio.run(bot_lobby.lobby_start_cmd(FakeUpdate(), FakeContext()))
+
+    assert len(sent) == 2
+    assert sent[0][0] == 10
+    assert "tg://user?id=u1" in sent[0][1]
+    assert "tg://user?id=u2" in sent[0][1]
+    assert sent[1][0] == 10

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -1,0 +1,16 @@
+import importlib
+import os
+
+def test_premium_unlimited_races(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAME_DATA_DIR", str(tmp_path))
+    from pathlib import Path
+    (Path(tmp_path) / "premium.txt").write_text("42\n", encoding="utf-8")
+    import premium
+    importlib.reload(premium)
+    import economy_v1
+    importlib.reload(economy_v1)
+    import game_api
+    importlib.reload(game_api)
+    p = economy_v1.load_player("42", "Tester")
+    for _ in range(game_api.MAX_RACES_PER_DAY + 5):
+        game_api._check_daily_limit(p)


### PR DESCRIPTION
## Summary
- make race log messages more vibrant with emojis and HTML styling
- remove incident penalties from race payouts
- allow premium users listed in `data/premium.txt` to race without daily limits
- limit lobbies to eight racers and broadcast car stats with gaps to each participant
- stream lobby race events to the server, including penalties and throttled segment updates
- tag lobby racers and send single start/result messages per group chat

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cd88d19b0832e92d8387b03b8bdfa