### PR TITLE
Add bonus code and display car stats with upgrades

### DIFF
--- a/bot_lobby.py
+++ b/bot_lobby.py
@@ -13,6 +13,7 @@ from lobby import (
     LOBBIES,
     find_user_lobby,
 )
+from bot import _uid, _uname, send_html, esc
 
 async def lobby_create_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     uid = _uid(update)
@@ -71,8 +72,9 @@ async def lobby_start_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await send_html(update, "Использование: <code>/lobby_start &lt;id&gt;</code>")
         return
     lid = context.args[0]
-    lobby_info = LOBBIES.get(lid, {}
-    if uid not in [p["user_id"] for p in lobby_info.get("players", [])]:
+    lobby_info = LOBBIES.get(lid, {})
+    player_stats = lobby_info.get("players", [])
+    if uid not in [p["user_id"] for p in player_stats]:
         await send_html(update, "Сначала присоединись к лобби")
         return
 

--- a/game_api.py
+++ b/game_api.py
@@ -10,6 +10,8 @@ from economy_v1 import (
     payout_for_race,
     reward_player,
     UPGRADE_POWER_BONUS,
+    UPGRADE_WEIGHT_BONUS,
+    UPGRADE_GRIP_BONUS,
     UPGRADE_CLASSES,
     PARTS_PER_CLASS,
     installed_parts,
@@ -101,6 +103,8 @@ def run_player_race(user_id: str, name: str, track_id: Optional[str]=None, laps:
         total_parts = min(installed_parts(progress), max_parts)
         if total_parts:
             car.power *= 1.0 + UPGRADE_POWER_BONUS * total_parts
+            car.mass *= max(0.0, 1.0 - UPGRADE_WEIGHT_BONUS * total_parts)
+            car.tire_grip *= 1.0 + UPGRADE_GRIP_BONUS * total_parts
 
     tid = track_id or p.current_track
     if not tid:

--- a/tests/test_bonus_code.py
+++ b/tests/test_bonus_code.py
@@ -1,0 +1,13 @@
+import importlib, os, pathlib
+
+def test_bonus_code_reward(tmp_path, monkeypatch):
+    monkeypatch.setenv("GAME_DATA_DIR", str(tmp_path))
+    import economy_v1
+    importlib.reload(economy_v1)
+    p = economy_v1.load_player("42", "Tester")
+    msg = economy_v1.redeem_bonus_code(p, "TestNewBounty")
+    assert "100000" in msg
+    assert p.balance == economy_v1.DEFAULT_START_BALANCE + 100_000
+    repo_data = pathlib.Path(__file__).resolve().parent.parent / "data"
+    monkeypatch.setenv("GAME_DATA_DIR", str(repo_data))
+    importlib.reload(economy_v1)

--- a/tests/test_car_stats.py
+++ b/tests/test_car_stats.py
@@ -1,0 +1,33 @@
+import os, sys, pathlib, pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+DATA_DIR = pathlib.Path(__file__).resolve().parent.parent / "data"
+
+
+@pytest.fixture(autouse=True)
+def _prepare(monkeypatch):
+    monkeypatch.setenv("GAME_DATA_DIR", str(DATA_DIR))
+    if "economy_v1" in sys.modules:
+        del sys.modules["economy_v1"]
+    yield
+
+
+def test_buy_car_shows_stats():
+    import economy_v1
+    p = economy_v1.Player(user_id="1", name="T")
+    msg = economy_v1.buy_car(p, "daewoo_matiz_2005")
+    assert "Мощность: 38" in msg
+    assert "Вес: 800" in msg
+
+
+def test_car_stats_upgrade_effect():
+    import economy_v1
+    p = economy_v1.Player(user_id="2", name="T", garage=["lada_2107"], balance=1_000_000)
+    before = economy_v1.car_stats(p, "lada_2107")
+    economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    economy_v1.buy_upgrade(p, "lada_2107", "engine")
+    after = economy_v1.car_stats(p, "lada_2107")
+    assert after["power"] > before["power"]
+    assert after["mass"] < before["mass"]
+    assert after["tire_grip"] > before["tire_grip"]

--- a/tests/test_upgrades.py
+++ b/tests/test_upgrades.py
@@ -12,7 +12,8 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _reload_modules():
-    importlib.reload(economy_v1)
+    import economy_v1 as _e
+    importlib.reload(_e)
 
 
 def test_upgrade_menu_has_custom_button():


### PR DESCRIPTION
## Summary
- grant 100k via new `TestNewBounty` bonus code
- show car power, weight and grip with upgrade effects in garage and on purchase
- apply upgrades to vehicle mass and grip during races

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cea23175c832e989da764dfff698d