### PR TITLE
feat: improve navigation and upgrade balance

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,8 @@ from bot_kb import (
     catalog_kb,
     tracks_kb,
     upgrade_parts_kb,
+    driver_kb,
+    lobby_main_kb,
 )
 from economy_v1 import (
     load_player,
@@ -29,8 +31,8 @@ from economy_v1 import (
     car_stats,
     redeem_bonus_code,
 )
-from game_api import run_player_race, get_upgrade_status, list_available_upgrades, buy_car_upgrade
-from lobby import find_user_lobby
+from game_api import run_player_race, get_upgrade_status, list_available_upgrades, buy_car_upgrade, load_car_by_id
+from lobby import find_user_lobby, create_lobby, join_lobby, leave_lobby, LOBBIES
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger("racing-bot")
@@ -146,8 +148,9 @@ async def setcar_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def driver(update: Update, context: ContextTypes.DEFAULT_TYPE):
     uid = _uid(update); name = _uname(update)
     p = load_player(uid, name)
+    kb = driver_kb()
     if not p.driver_json:
-        await send_html(update, "Профиль пилота появится после первой гонки (<code>/race</code>).")
+        await send_html(update, "Профиль пилота появится после первой гонки (<code>/race</code>).", reply_markup=kb)
         return
     from models_v2 import DriverProfile
     d = DriverProfile.from_json(p.driver_json)
@@ -156,7 +159,30 @@ async def driver(update: Update, context: ContextTypes.DEFAULT_TYPE):
     for k in ["braking","consistency","stress","throttle","cornering","starts"]:
         if k in skills:
             lines.append(f"{esc(k.capitalize())}: {skills[k]:.1f}")
-    await send_html(update, "\n".join(lines))
+    await send_html(update, "\n".join(lines), reply_markup=kb)
+
+
+async def lobby_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    uid = _uid(update); name = _uname(update)
+    p = load_player(uid, name)
+    lid = find_user_lobby(uid)
+    if lid:
+        info = LOBBIES.get(lid, {})
+        players = info.get("players", [])
+        lines = [f"<b>Лобби {esc(lid)}</b>"]
+        for pl in players:
+            car = pl.get("car", "?")
+            lines.append(f"- {esc(pl['name'])} — {esc(car)}")
+        host = players and players[0]["user_id"] == uid
+        kb = lobby_main_kb(lid, host)
+    else:
+        lines = [
+            "Ты не в лобби.",
+            "Создай: /lobby_create <track_id>",
+            "Вступи: /lobby_join <id>",
+        ]
+        kb = lobby_main_kb()
+    await send_html(update, "\n".join(lines), reply_markup=kb)
 
 async def track_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.effective_chat.send_message("<b>Выбор трассы:</b>", parse_mode=ParseMode.HTML, reply_markup=tracks_kb())
@@ -285,6 +311,41 @@ async def on_callback(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif data == "nav:help":
         await query.answer()
         await help_cmd(update, context)
+    elif data == "nav:driver":
+        await query.answer()
+        await driver(update, context)
+    elif data == "nav:bonus":
+        await query.answer()
+        await send_html(update, "Использование: <code>/bonus &lt;код&gt;</code>")
+    elif data == "nav:lobby":
+        await query.answer()
+        await lobby_menu(update, context)
+    elif data == "lobby_create":
+        await query.answer()
+        p = load_player(uid, name)
+        if not p.current_track or not p.current_car:
+            await send_html(update, "Сначала выбери машину и трассу")
+        else:
+            lid = create_lobby(p.current_track)
+            car = load_car_by_id(p.current_car)
+            join_lobby(
+                lid,
+                uid,
+                name,
+                chat_id=str(update.effective_chat.id),
+                mass=car.mass,
+                power=car.power,
+                car=car.name,
+            )
+            from bot_lobby import broadcast_lobby_state
+            await broadcast_lobby_state(lid, getattr(context, "bot", None))
+    elif data.startswith("lobby_leave:"):
+        await query.answer()
+        lid = data.split(":",1)[1]
+        leave_lobby(lid, uid)
+        await send_html(update, "Лобби покинуто")
+        from bot_lobby import broadcast_lobby_state
+        await broadcast_lobby_state(lid, getattr(context, "bot", None))
     elif data.startswith("upgrades:"):
         await query.answer()
         car_id = data.split(":",1)[1]
@@ -321,6 +382,7 @@ def build_app() -> Application:
     app.add_handler(CommandHandler("garage", garage))
     app.add_handler(CommandHandler("setcar", setcar_cmd))
     app.add_handler(CommandHandler("driver", driver))
+    app.add_handler(CommandHandler("lobby", lobby_menu))
     app.add_handler(CommandHandler("track", track_cmd))
     app.add_handler(CommandHandler("settrack", settrack_cmd))
     app.add_handler(CommandHandler("upgrades", upgrades_cmd))

--- a/bot_kb.py
+++ b/bot_kb.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from economy_v1 import list_catalog, list_tracks
@@ -9,9 +9,9 @@ def fmt_money(v: int) -> str:
     return f"{v:,}".replace(",", " ")
 
 
-def main_menu_kb() -> InlineKeyboardMarkup:
-    """Main menu with quick navigation links."""
-    return InlineKeyboardMarkup([
+def _nav_menu_rows() -> List[List[InlineKeyboardButton]]:
+    """Standard navigation buttons shown on every screen."""
+    return [
         [
             InlineKeyboardButton("Справка", callback_data="nav:help"),
             InlineKeyboardButton("Гараж", callback_data="nav:garage"),
@@ -20,7 +20,22 @@ def main_menu_kb() -> InlineKeyboardMarkup:
             InlineKeyboardButton("Каталог", callback_data="nav:catalog"),
             InlineKeyboardButton("Трассы", callback_data="nav:tracks"),
         ],
-    ])
+        [
+            InlineKeyboardButton("Водитель", callback_data="nav:driver"),
+            InlineKeyboardButton("Лобби", callback_data="nav:lobby"),
+            InlineKeyboardButton("Промокод", callback_data="nav:bonus"),
+        ],
+    ]
+
+
+def _with_nav(rows: List[List[InlineKeyboardButton]]) -> InlineKeyboardMarkup:
+    """Append navigation rows to keyboard rows and return markup."""
+    return InlineKeyboardMarkup(_nav_menu_rows() + rows)
+
+
+def main_menu_kb() -> InlineKeyboardMarkup:
+    """Main menu with quick navigation links."""
+    return InlineKeyboardMarkup(_nav_menu_rows())
 
 
 def garage_kb(p) -> InlineKeyboardMarkup:
@@ -31,7 +46,7 @@ def garage_kb(p) -> InlineKeyboardMarkup:
         name = cat["cars"].get(cid, {}).get("name", cid)
         rows.append([InlineKeyboardButton(name, callback_data=f"upgrades:{cid}")])
     rows.append([InlineKeyboardButton("Обновить", callback_data="nav:garage")])
-    return InlineKeyboardMarkup(rows)
+    return _with_nav(rows)
 
 
 def catalog_kb(cat: Dict) -> InlineKeyboardMarkup:
@@ -42,7 +57,7 @@ def catalog_kb(cat: Dict) -> InlineKeyboardMarkup:
         label = f"{item['name']} — {fmt_money(item['price'])}"
         rows.append([InlineKeyboardButton(label, callback_data=f"buy:{cid}")])
     rows.append([InlineKeyboardButton("Обновить", callback_data="nav:catalog")])
-    return InlineKeyboardMarkup(rows)
+    return _with_nav(rows)
 
 
 def tracks_kb() -> InlineKeyboardMarkup:
@@ -51,7 +66,7 @@ def tracks_kb() -> InlineKeyboardMarkup:
     for tid, name in list(list_tracks().items())[:12]:
         rows.append([InlineKeyboardButton(f"{name}", callback_data=f"settrack:{tid}")])
     rows.append([InlineKeyboardButton("Обновить", callback_data="nav:tracks")])
-    return InlineKeyboardMarkup(rows)
+    return _with_nav(rows)
 
 
 def upgrade_parts_kb(car_id: str, parts: list) -> InlineKeyboardMarkup:
@@ -60,4 +75,22 @@ def upgrade_parts_kb(car_id: str, parts: list) -> InlineKeyboardMarkup:
     for part in parts:
         rows.append([InlineKeyboardButton(part["name"], callback_data=f"buyupg:{car_id}:{part['id']}")])
     rows.append([InlineKeyboardButton("Назад", callback_data="nav:garage")])
-    return InlineKeyboardMarkup(rows)
+    return _with_nav(rows)
+
+
+def driver_kb() -> InlineKeyboardMarkup:
+    """Keyboard for driver profile actions."""
+    rows = [[InlineKeyboardButton("Ввести бонускод", callback_data="nav:bonus")]]
+    return _with_nav(rows)
+
+
+def lobby_main_kb(lobby_id: str | None = None, is_host: bool = False) -> InlineKeyboardMarkup:
+    """Keyboard for lobby view and actions."""
+    rows: List[List[InlineKeyboardButton]] = []
+    if lobby_id:
+        rows.append([InlineKeyboardButton("Выйти", callback_data=f"lobby_leave:{lobby_id}")])
+        rows.append([InlineKeyboardButton("Обновить", callback_data="nav:lobby")])
+    else:
+        rows.append([InlineKeyboardButton("Создать лобби", callback_data="lobby_create")])
+        rows.append([InlineKeyboardButton("Обновить", callback_data="nav:lobby")])
+    return _with_nav(rows)

--- a/data/cars/daewoo_matiz_2005.json
+++ b/data/cars/daewoo_matiz_2005.json
@@ -6,5 +6,6 @@
   "cd": 0.35,
   "area": 1.9,
   "tire_grip": 0.9,
+  "engine_volume": 0.8,
   "price": 2500
 }

--- a/game_api.py
+++ b/game_api.py
@@ -9,12 +9,10 @@ from economy_v1 import (
     list_catalog,
     payout_for_race,
     reward_player,
-    UPGRADE_POWER_BONUS,
-    UPGRADE_WEIGHT_BONUS,
-    UPGRADE_GRIP_BONUS,
+    UPGRADE_EFFECTS,
     UPGRADE_CLASSES,
     PARTS_PER_CLASS,
-    installed_parts,
+    all_installed_parts,
     buy_upgrade,
     upgrade_status,
     list_upgrade_parts,
@@ -100,11 +98,12 @@ def run_player_race(user_id: str, name: str, track_id: Optional[str]=None, laps:
     progress = p.upgrades.get(car.id)
     if progress:
         max_parts = UPGRADE_CLASSES.get(tier, 0) * PARTS_PER_CLASS
-        total_parts = min(installed_parts(progress), max_parts)
-        if total_parts:
-            car.power *= 1.0 + UPGRADE_POWER_BONUS * total_parts
-            car.mass *= max(0.0, 1.0 - UPGRADE_WEIGHT_BONUS * total_parts)
-            car.tire_grip *= 1.0 + UPGRADE_GRIP_BONUS * total_parts
+        applied = all_installed_parts(progress)[:max_parts]
+        for pid in applied:
+            eff = UPGRADE_EFFECTS.get(pid, {})
+            car.power *= 1.0 + eff.get("power", 0.0)
+            car.mass *= 1.0 + eff.get("mass", 0.0)
+            car.tire_grip *= 1.0 + eff.get("tire_grip", 0.0)
 
     tid = track_id or p.current_track
     if not tid:

--- a/lobby.py
+++ b/lobby.py
@@ -44,6 +44,7 @@ def join_lobby(
     chat_id: str,
     mass: float = 0.0,
     power: float = 0.0,
+    car: str = "",
 ) -> None:
     lobby = LOBBIES.get(lobby_id)
     if not lobby:
@@ -63,6 +64,7 @@ def join_lobby(
                 "chat_id": chat_id,
                 "mass": mass,
                 "power": power,
+                "car": car,
             }
         )
 

--- a/tests/test_car_stats.py
+++ b/tests/test_car_stats.py
@@ -23,11 +23,28 @@ def test_buy_car_shows_stats():
 
 def test_car_stats_upgrade_effect():
     import economy_v1
-    p = economy_v1.Player(user_id="2", name="T", garage=["lada_2107"], balance=1_000_000)
-    before = economy_v1.car_stats(p, "lada_2107")
-    economy_v1.buy_upgrade(p, "lada_2107", "custom")
-    economy_v1.buy_upgrade(p, "lada_2107", "engine")
-    after = economy_v1.car_stats(p, "lada_2107")
+    cid = "daewoo_matiz_2005"
+    p = economy_v1.Player(user_id="2", name="T", garage=[cid], balance=1_000_000)
+    before = economy_v1.car_stats(p, cid)
+    economy_v1.buy_upgrade(p, cid, "custom")
+    economy_v1.buy_upgrade(p, cid, "engine")
+    after = economy_v1.car_stats(p, cid)
     assert after["power"] > before["power"]
-    assert after["mass"] < before["mass"]
-    assert after["tire_grip"] > before["tire_grip"]
+    assert after["mass"] == pytest.approx(before["mass"])
+    assert after["tire_grip"] == pytest.approx(before["tire_grip"])
+    assert after["engine_volume"] > before["engine_volume"]
+
+
+def test_upgrade_individual_effects():
+    import economy_v1
+    cid = "daewoo_matiz_2005"
+    p = economy_v1.Player(user_id="3", name="T", garage=[cid], balance=1_000_000)
+    economy_v1.buy_upgrade(p, cid, "custom")
+    before = economy_v1.car_stats(p, cid)
+    economy_v1.buy_upgrade(p, cid, "weight")
+    after_weight = economy_v1.car_stats(p, cid)
+    assert after_weight["mass"] < before["mass"]
+    assert after_weight["power"] == pytest.approx(before["power"])
+    economy_v1.buy_upgrade(p, cid, "tires")
+    after_tires = economy_v1.car_stats(p, cid)
+    assert after_tires["tire_grip"] > after_weight["tire_grip"]

--- a/tests/test_driver_buttons.py
+++ b/tests/test_driver_buttons.py
@@ -1,0 +1,10 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from bot_kb import driver_kb
+
+
+def test_driver_has_bonus_button():
+    kb = driver_kb()
+    labels = [btn.text for row in kb.inline_keyboard for btn in row]
+    assert "Ввести бонускод" in labels

--- a/tests/test_lobby_join.py
+++ b/tests/test_lobby_join.py
@@ -1,0 +1,11 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from lobby import reset_lobbies, create_lobby, join_lobby, LOBBIES
+
+
+def test_join_lobby_stores_car():
+    reset_lobbies()
+    lid = create_lobby("track1")
+    join_lobby(lid, "u1", "Alice", chat_id="1", car="Matiz")
+    assert LOBBIES[lid]["players"][0]["car"] == "Matiz"

--- a/tests/test_main_menu_buttons.py
+++ b/tests/test_main_menu_buttons.py
@@ -11,3 +11,6 @@ def test_main_menu_has_buttons():
     assert "Гараж" in labels
     assert "Каталог" in labels
     assert "Трассы" in labels
+    assert "Водитель" in labels
+    assert "Лобби" in labels
+    assert "Промокод" in labels


### PR DESCRIPTION
## Summary
- add lobby and promo code buttons to persistent navigation
- broadcast lobby updates showing each player's car
- test lobby car tracking and navigation buttons

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cf96eb9e4832eb1962999abe8a708