### PR TITLE
Fix navigation keyboard initialization

### DIFF
--- a/bot_kb.py
+++ b/bot_kb.py
@@ -23,6 +23,8 @@ def _nav_menu_rows() -> List[List[InlineKeyboardButton]]:
         [
             InlineKeyboardButton("Водитель", callback_data="nav:driver"),
             InlineKeyboardButton("Лобби", callback_data="nav:lobby"),
+        ],
+    ]
 
 
 def _with_nav(rows: List[List[InlineKeyboardButton]]) -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- close nav menu list in `bot_kb` to avoid SyntaxError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d0ec1b1f8832e887798b32f5e5903