### PR TITLE
Escalate upgrade costs and effects by level

### DIFF
--- a/data/cars/lada_2107.json
+++ b/data/cars/lada_2107.json
@@ -6,5 +6,10 @@
   "cd": 0.45,
   "area": 2.1,
   "tire_grip": 0.92,
-  "price": 3000
+  "price": 3000,
+  "upgrade_multipliers": {
+    "ecu": 0.4,
+    "intake": 1.1,
+    "exhaust": 0.7
+  }
 }

--- a/tests/test_car_stats.py
+++ b/tests/test_car_stats.py
@@ -48,3 +48,26 @@ def test_upgrade_individual_effects():
     economy_v1.buy_upgrade(p, cid, "tires")
     after_tires = economy_v1.car_stats(p, cid)
     assert after_tires["tire_grip"] > after_weight["tire_grip"]
+
+
+def test_high_level_parts_more_effective():
+    import economy_v1
+    cid = "daewoo_matiz_2005"
+    p = economy_v1.Player(user_id="4", name="T", garage=[cid], balance=1_000_000)
+
+    economy_v1.buy_upgrade(p, cid, "custom")
+    before_lvl0 = economy_v1.car_stats(p, cid)
+    economy_v1.buy_upgrade(p, cid, "engine")
+    after_lvl0 = economy_v1.car_stats(p, cid)
+    ratio_lvl0 = after_lvl0["power"] / before_lvl0["power"]
+
+    for part in economy_v1.UPGRADE_PARTS:
+        if part != "engine":
+            economy_v1.buy_upgrade(p, cid, part)
+    economy_v1.buy_upgrade(p, cid, "custom")
+    before_lvl1 = economy_v1.car_stats(p, cid)
+    economy_v1.buy_upgrade(p, cid, "engine")
+    after_lvl1 = economy_v1.car_stats(p, cid)
+    ratio_lvl1 = after_lvl1["power"] / before_lvl1["power"]
+
+    assert ratio_lvl1 > ratio_lvl0

--- a/tests/test_upgrades.py
+++ b/tests/test_upgrades.py
@@ -34,3 +34,76 @@ def test_custom_then_generic_parts():
     for part in parts:
         assert "desc" in part
 
+
+def test_upgrade_price_constant_within_level():
+    p = economy_v1.Player(user_id="3", name="T", garage=["lada_2107"])
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    custom_cost = economy_v1.upgrade_cost(price, 0, "custom", "lada_2107")
+    engine_cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    turbo_cost = economy_v1.upgrade_cost(price, 0, "turbo", "lada_2107")
+
+    msg = economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    assert economy_v1.fmt_money(custom_cost) in msg
+
+    first = economy_v1.buy_upgrade(p, "lada_2107", "engine")
+    assert economy_v1.fmt_money(engine_cost) in first
+
+    second = economy_v1.buy_upgrade(p, "lada_2107", "turbo")
+    assert economy_v1.fmt_money(turbo_cost) in second
+
+
+def test_upgrade_price_increases_next_level():
+    p = economy_v1.Player(user_id="4", name="T", garage=["lada_2107"])
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    lvl0_custom = economy_v1.upgrade_cost(price, 0, "custom", "lada_2107")
+    lvl0_engine = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+
+    economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    for part_id in economy_v1.UPGRADE_PARTS:
+        economy_v1.buy_upgrade(p, "lada_2107", part_id)
+
+    lvl1_custom = economy_v1.upgrade_cost(price, 1, "custom", "lada_2107")
+    assert lvl1_custom > lvl0_custom
+    msg = economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    assert economy_v1.fmt_money(lvl1_custom) in msg
+
+    lvl1_engine = economy_v1.upgrade_cost(price, 1, "engine", "lada_2107")
+    assert lvl1_engine > lvl0_engine
+    msg_part = economy_v1.buy_upgrade(p, "lada_2107", "engine")
+    assert economy_v1.fmt_money(lvl1_engine) in msg_part
+
+
+def test_part_costs_vary():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    ecu_cost = economy_v1.upgrade_cost(price, 0, "ecu", "lada_2107")
+    engine_cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    intake_cost = economy_v1.upgrade_cost(price, 0, "intake", "lada_2107")
+    exhaust_cost = economy_v1.upgrade_cost(price, 0, "exhaust", "lada_2107")
+    assert ecu_cost < engine_cost
+    assert intake_cost > exhaust_cost
+
+
+def test_car_specific_multiplier_overrides_default():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    default_ecu = economy_v1.upgrade_cost(price, 0, "ecu")
+    lada_ecu = economy_v1.upgrade_cost(price, 0, "ecu", "lada_2107")
+    lvl_mult = economy_v1.UPGRADE_LEVEL_COST_MULTS[0]
+    expected = economy_v1.round_price(price * economy_v1.UPGRADE_BASE_COST_MULT * lvl_mult * 0.4)
+    assert lada_ecu == expected
+    assert lada_ecu < default_ecu
+
+
+def test_prices_are_rounded():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    assert price % 10 == 0
+    cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    assert cost % 10 == 0
+    # ensure half values round upwards
+    assert economy_v1.round_price(65) == 70
+    assert economy_v1.round_price(64) == 60
+


### PR DESCRIPTION
## Summary
- Scale upgrade prices with a dedicated per-level multiplier list
- Boost later-stage upgrades with level-based effectiveness multipliers
- Verify car-specific cost overrides and stronger high-level parts in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689d1b1ac400832e8d943b5a0193b6e3