### PR TITLE
Improve upgrade pricing and rounding

### DIFF
--- a/data/cars/lada_2107.json
+++ b/data/cars/lada_2107.json
@@ -6,5 +6,10 @@
   "cd": 0.45,
   "area": 2.1,
   "tire_grip": 0.92,
-  "price": 3000
+  "price": 3000,
+  "upgrade_multipliers": {
+    "ecu": 0.4,
+    "intake": 1.1,
+    "exhaust": 0.7
+  }
 }

--- a/economy_v1.py
+++ b/economy_v1.py
@@ -28,28 +28,83 @@ UPGRADE_CLASSES = {
     "gt": 2,
     "hyper": 1,
 }
-UPGRADE_COST_MULT = 0.1  # fraction of car price per part
+UPGRADE_BASE_COST_MULT = 0.1  # fraction of car price per part at level 0
 
 # individual upgrade effects per installed part
 # values represent fractional change applied multiplicatively
 UPGRADE_EFFECTS: Dict[str, Dict[str, float]] = {
-    "engine": {"power": 0.06, "engine_volume": 0.02},
-    "turbo": {"power": 0.08, "engine_volume": 0.01},
-    "exhaust": {"power": 0.03},
-    "intake": {"power": 0.02},
+    "engine": {"power": 0.06, "engine_volume": 0.02, "mass": 0.005},
+    "turbo": {"power": 0.08, "engine_volume": 0.01, "mass": 0.01},
+    "exhaust": {"power": 0.03, "mass": -0.004},
+    "intake": {"power": 0.02, "engine_volume": 0.01},
     "ecu": {"power": 0.04},
-    "fuel": {"power": 0.03},
-    "cooling": {"power": 0.02},
+    "fuel": {"power": 0.03, "mass": 0.002},
+    "cooling": {"power": 0.02, "mass": 0.004},
     "transmission": {"power": 0.02, "mass": -0.003},
-    "suspension": {"tire_grip": 0.02},
-    "tires": {"tire_grip": 0.03},
+    "suspension": {"tire_grip": 0.02, "mass": 0.003},
+    "tires": {"tire_grip": 0.03, "mass": 0.002},
     "aero": {"tire_grip": 0.01, "mass": -0.002},
     "weight": {"mass": -0.01},
+    "custom": {"power": 0.05, "tire_grip": 0.02, "mass": -0.01},
 }
 
 def fmt_money(v: int) -> str:
     """Format integer value with spaces for thousands."""
     return f"{v:,}".replace(",", " ")
+
+
+def round_price(value: float) -> int:
+    """Round monetary value to the nearest multiple of ten, halves rounding up."""
+    return int((value + 5) // 10 * 10)
+
+
+UPGRADE_PART_MULT: Dict[str, float] = {
+    "engine": 1.2,
+    "turbo": 1.3,
+    "exhaust": 0.8,
+    "intake": 0.9,
+    "ecu": 0.5,
+    "fuel": 0.7,
+    "cooling": 0.6,
+    "transmission": 1.1,
+    "suspension": 0.8,
+    "tires": 0.9,
+    "aero": 0.7,
+    "weight": 0.9,
+    "custom": 1.0,
+}
+
+
+_CAR_UPGRADE_MULT_CACHE: Dict[str, Dict[str, float]] = {}
+
+
+def _car_upgrade_mults(car_id: str) -> Dict[str, float]:
+    """Return part multiplier overrides for a specific car."""
+    if car_id not in _CAR_UPGRADE_MULT_CACHE:
+        try:
+            data = json.loads((CARS_DIR / f"{car_id}.json").read_text(encoding="utf-8"))
+            _CAR_UPGRADE_MULT_CACHE[car_id] = data.get("upgrade_multipliers", {})
+        except Exception:
+            _CAR_UPGRADE_MULT_CACHE[car_id] = {}
+    return _CAR_UPGRADE_MULT_CACHE[car_id]
+
+
+def part_cost_multiplier(part_id: str, car_id: Optional[str]) -> float:
+    """Get cost multiplier for a part, considering car-specific overrides."""
+    base = UPGRADE_PART_MULT.get(part_id, 1.0)
+    if car_id:
+        mults = _car_upgrade_mults(car_id)
+        return mults.get(part_id, base)
+    return base
+
+
+def upgrade_cost(
+    car_price: int, level: int, part_id: str, car_id: Optional[str] = None
+) -> int:
+    """Return integer cost for an upgrade part at the given level."""
+    mult = part_cost_multiplier(part_id, car_id)
+    base = car_price * UPGRADE_BASE_COST_MULT * mult * (level + 1)
+    return round_price(base)
 
 # available upgrade parts
 UPGRADE_PARTS = {
@@ -104,9 +159,11 @@ def installed_parts(progress: UpgradeProgress) -> int:
 def all_installed_parts(progress: UpgradeProgress) -> List[str]:
     """Return list of part ids installed across all levels."""
     parts: List[str] = []
-    full = list(UPGRADE_PARTS.keys())
+    full = ["custom"] + list(UPGRADE_PARTS.keys())
     for _ in range(progress.level):
         parts.extend(full)
+    if progress.custom_done:
+        parts.append("custom")
     parts.extend(progress.parts)
     return parts
 
@@ -228,8 +285,8 @@ def _price_tier(car: Dict) -> Tuple[int, str]:
             grip = float(car.get("tire_grip", 1.0))
             cd = float(car.get("cd", 0.35))
             adj = 1.0 + 0.15 * (grip - 1.0) + 0.10 * (max(0.25, min(0.6, cd)) - 0.35)
-            return int(base * adj), name
-    return 5000, "starter"
+            return round_price(base * adj), name
+    return round_price(5000), "starter"
 
 def list_catalog() -> Dict:
     out = {"cars": {}}
@@ -380,8 +437,7 @@ def buy_upgrade(p: Player, car_id: str, part_id: str) -> str:
     if not progress.custom_done:
         if part_id != "custom":
             return "🚫 Сначала установи специальный комплект."
-        total_installed = installed_parts(progress)
-        cost = int(item["price"] * UPGRADE_COST_MULT * (total_installed + 1))
+        cost = upgrade_cost(item["price"], progress.level, "custom", car_id)
         if p.balance < cost:
             return f"💸 Не хватает средств: нужно {fmt_money(cost)}, на счету {fmt_money(p.balance)}."
         before = car_stats(p, car_id)
@@ -402,8 +458,7 @@ def buy_upgrade(p: Player, car_id: str, part_id: str) -> str:
         return "🚫 Нет такой запчасти."
     if part_id in progress.parts:
         return "🚫 Эта запчасть уже установлена на текущем уровне."
-    total_installed = installed_parts(progress)
-    cost = int(item["price"] * UPGRADE_COST_MULT * (total_installed + 1))
+    cost = upgrade_cost(item["price"], progress.level, part_id, car_id)
     if p.balance < cost:
         return f"💸 Не хватает средств: нужно {fmt_money(cost)}, на счету {fmt_money(p.balance)}."
     before = car_stats(p, car_id)

--- a/tests/test_car_stats.py
+++ b/tests/test_car_stats.py
@@ -30,8 +30,8 @@ def test_car_stats_upgrade_effect():
     economy_v1.buy_upgrade(p, cid, "engine")
     after = economy_v1.car_stats(p, cid)
     assert after["power"] > before["power"]
-    assert after["mass"] == pytest.approx(before["mass"])
-    assert after["tire_grip"] == pytest.approx(before["tire_grip"])
+    assert after["mass"] < before["mass"]
+    assert after["tire_grip"] > before["tire_grip"]
     assert after["engine_volume"] > before["engine_volume"]
 
 
@@ -48,3 +48,15 @@ def test_upgrade_individual_effects():
     economy_v1.buy_upgrade(p, cid, "tires")
     after_tires = economy_v1.car_stats(p, cid)
     assert after_tires["tire_grip"] > after_weight["tire_grip"]
+
+
+def test_custom_upgrade_changes_stats():
+    import economy_v1
+    cid = "daewoo_matiz_2005"
+    p = economy_v1.Player(user_id="4", name="T", garage=[cid], balance=1_000_000)
+    before = economy_v1.car_stats(p, cid)
+    economy_v1.buy_upgrade(p, cid, "custom")
+    after = economy_v1.car_stats(p, cid)
+    assert after["power"] > before["power"]
+    assert after["mass"] < before["mass"]
+    assert after["tire_grip"] > before["tire_grip"]

--- a/tests/test_upgrades.py
+++ b/tests/test_upgrades.py
@@ -34,3 +34,75 @@ def test_custom_then_generic_parts():
     for part in parts:
         assert "desc" in part
 
+
+def test_upgrade_price_constant_within_level():
+    p = economy_v1.Player(user_id="3", name="T", garage=["lada_2107"])
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    custom_cost = economy_v1.upgrade_cost(price, 0, "custom", "lada_2107")
+    engine_cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    turbo_cost = economy_v1.upgrade_cost(price, 0, "turbo", "lada_2107")
+
+    msg = economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    assert economy_v1.fmt_money(custom_cost) in msg
+
+    first = economy_v1.buy_upgrade(p, "lada_2107", "engine")
+    assert economy_v1.fmt_money(engine_cost) in first
+
+    second = economy_v1.buy_upgrade(p, "lada_2107", "turbo")
+    assert economy_v1.fmt_money(turbo_cost) in second
+
+
+def test_upgrade_price_increases_next_level():
+    p = economy_v1.Player(user_id="4", name="T", garage=["lada_2107"])
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    lvl0_custom = economy_v1.upgrade_cost(price, 0, "custom", "lada_2107")
+    lvl0_engine = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+
+    economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    for part_id in economy_v1.UPGRADE_PARTS:
+        economy_v1.buy_upgrade(p, "lada_2107", part_id)
+
+    lvl1_custom = economy_v1.upgrade_cost(price, 1, "custom", "lada_2107")
+    assert lvl1_custom > lvl0_custom
+    msg = economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    assert economy_v1.fmt_money(lvl1_custom) in msg
+
+    lvl1_engine = economy_v1.upgrade_cost(price, 1, "engine", "lada_2107")
+    assert lvl1_engine > lvl0_engine
+    msg_part = economy_v1.buy_upgrade(p, "lada_2107", "engine")
+    assert economy_v1.fmt_money(lvl1_engine) in msg_part
+
+
+def test_part_costs_vary():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    ecu_cost = economy_v1.upgrade_cost(price, 0, "ecu", "lada_2107")
+    engine_cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    intake_cost = economy_v1.upgrade_cost(price, 0, "intake", "lada_2107")
+    exhaust_cost = economy_v1.upgrade_cost(price, 0, "exhaust", "lada_2107")
+    assert ecu_cost < engine_cost
+    assert intake_cost > exhaust_cost
+
+
+def test_car_specific_multiplier_overrides_default():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    default_ecu = economy_v1.upgrade_cost(price, 0, "ecu")
+    lada_ecu = economy_v1.upgrade_cost(price, 0, "ecu", "lada_2107")
+    expected = economy_v1.round_price(price * economy_v1.UPGRADE_BASE_COST_MULT * 0.4)
+    assert lada_ecu == expected
+    assert lada_ecu < default_ecu
+
+
+def test_prices_are_rounded():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    assert price % 10 == 0
+    cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    assert cost % 10 == 0
+    # ensure half values round upwards
+    assert economy_v1.round_price(65) == 70
+    assert economy_v1.round_price(64) == 60
+


### PR DESCRIPTION
## Summary
- Add side effects and bonuses to upgrade parts, including custom upgrade benefits that persist across levels
- Apply custom upgrade effects in stat calculations to keep bonuses active
- Test that upgrades modify power, mass, and grip as expected

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689d1b1ac400832e8d943b5a0193b6e3