### PR TITLE
Rebalance upgrades with completion bonuses and realistic pricing

### DIFF
--- a/data/cars/bugatti.json
+++ b/data/cars/bugatti.json
@@ -5,5 +5,10 @@
     "mass": 1996,
     "cd": 0.38,
     "area": 2.6,
-    "tire_grip": 1.3
+    "tire_grip": 1.3,
+    "upgrade_multipliers": {
+        "ecu": 1.6,
+        "intake": 1.5,
+        "exhaust": 1.4
+    }
 }

--- a/data/cars/daewoo_matiz_2005.json
+++ b/data/cars/daewoo_matiz_2005.json
@@ -7,5 +7,10 @@
   "area": 1.9,
   "tire_grip": 0.9,
   "engine_volume": 0.8,
-  "price": 2500
+  "price": 2500,
+  "upgrade_multipliers": {
+    "ecu": 0.6,
+    "intake": 0.85,
+    "exhaust": 0.8
+  }
 }

--- a/data/cars/fiat_panda_2007.json
+++ b/data/cars/fiat_panda_2007.json
@@ -6,5 +6,10 @@
   "cd": 0.34,
   "area": 2.0,
   "tire_grip": 0.91,
-  "price": 3300
+  "price": 3300,
+  "upgrade_multipliers": {
+    "ecu": 0.65,
+    "intake": 0.9,
+    "exhaust": 0.85
+  }
 }

--- a/data/cars/golf_gti_mk7.json
+++ b/data/cars/golf_gti_mk7.json
@@ -5,5 +5,10 @@
     "mass": 1350,
     "cd": 0.3,
     "area": 2.2,
-    "tire_grip": 1.2
+    "tire_grip": 1.2,
+    "upgrade_multipliers": {
+        "ecu": 1.25,
+        "intake": 1.15,
+        "exhaust": 1.05
+    }
 }

--- a/data/cars/hyundai_getz_2003.json
+++ b/data/cars/hyundai_getz_2003.json
@@ -6,5 +6,10 @@
   "cd": 0.36,
   "area": 2.05,
   "tire_grip": 0.92,
-  "price": 3400
+  "price": 3400,
+  "upgrade_multipliers": {
+    "ecu": 0.65,
+    "intake": 0.9,
+    "exhaust": 0.85
+  }
 }

--- a/data/cars/lada_2107.json
+++ b/data/cars/lada_2107.json
@@ -6,5 +6,10 @@
   "cd": 0.45,
   "area": 2.1,
   "tire_grip": 0.92,
-  "price": 3000
+  "price": 3000,
+  "upgrade_multipliers": {
+    "ecu": 0.4,
+    "intake": 0.85,
+    "exhaust": 0.75
+  }
 }

--- a/data/cars/mercedes.json
+++ b/data/cars/mercedes.json
@@ -5,5 +5,10 @@
     "mass": 1300,
     "cd": 0.35,
     "area": 1.9,
-    "tire_grip": 1.3
+    "tire_grip": 1.3,
+    "upgrade_multipliers": {
+        "ecu": 1.4,
+        "intake": 1.3,
+        "exhaust": 1.2
+    }
 }

--- a/data/cars/nexia_1995.json
+++ b/data/cars/nexia_1995.json
@@ -5,5 +5,10 @@
     "mass": 1000,
     "cd": 0.34,
     "area": 2.1,
-    "tire_grip": 1.0
+    "tire_grip": 1.0,
+    "upgrade_multipliers": {
+        "ecu": 0.6,
+        "intake": 0.85,
+        "exhaust": 0.8
+    }
 }

--- a/data/cars/nissan_micra_k11.json
+++ b/data/cars/nissan_micra_k11.json
@@ -6,5 +6,10 @@
   "cd": 0.35,
   "area": 2.0,
   "tire_grip": 0.91,
-  "price": 3200
+  "price": 3200,
+  "upgrade_multipliers": {
+    "ecu": 0.65,
+    "intake": 0.9,
+    "exhaust": 0.85
+  }
 }

--- a/data/cars/opel_corsa_b_1999.json
+++ b/data/cars/opel_corsa_b_1999.json
@@ -6,5 +6,10 @@
   "cd": 0.36,
   "area": 2.0,
   "tire_grip": 0.92,
-  "price": 3600
+  "price": 3600,
+  "upgrade_multipliers": {
+    "ecu": 0.65,
+    "intake": 0.9,
+    "exhaust": 0.85
+  }
 }

--- a/data/cars/porsche_gt3_992.json
+++ b/data/cars/porsche_gt3_992.json
@@ -5,5 +5,10 @@
     "mass": 1430,
     "cd": 0.32,
     "area": 2.05,
-    "tire_grip": 1.3
+    "tire_grip": 1.3,
+    "upgrade_multipliers": {
+        "ecu": 1.4,
+        "intake": 1.3,
+        "exhaust": 1.25
+    }
 }

--- a/tests/test_upgrades.py
+++ b/tests/test_upgrades.py
@@ -34,3 +34,91 @@ def test_custom_then_generic_parts():
     for part in parts:
         assert "desc" in part
 
+
+def test_upgrade_price_constant_within_level():
+    p = economy_v1.Player(user_id="3", name="T", garage=["lada_2107"])
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    custom_cost = economy_v1.upgrade_cost(price, 0, "custom", "lada_2107")
+    engine_cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    turbo_cost = economy_v1.upgrade_cost(price, 0, "turbo", "lada_2107")
+
+    msg = economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    assert economy_v1.fmt_money(custom_cost) in msg
+
+    first = economy_v1.buy_upgrade(p, "lada_2107", "engine")
+    assert economy_v1.fmt_money(engine_cost) in first
+
+    second = economy_v1.buy_upgrade(p, "lada_2107", "turbo")
+    assert economy_v1.fmt_money(turbo_cost) in second
+
+
+def test_upgrade_price_increases_next_level():
+    p = economy_v1.Player(user_id="4", name="T", garage=["lada_2107"])
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    lvl0_custom = economy_v1.upgrade_cost(price, 0, "custom", "lada_2107")
+    lvl0_engine = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+
+    economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    for part_id in economy_v1.UPGRADE_PARTS:
+        economy_v1.buy_upgrade(p, "lada_2107", part_id)
+
+    lvl1_custom = economy_v1.upgrade_cost(price, 1, "custom", "lada_2107")
+    assert lvl1_custom > lvl0_custom
+    msg = economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    assert economy_v1.fmt_money(lvl1_custom) in msg
+
+    lvl1_engine = economy_v1.upgrade_cost(price, 1, "engine", "lada_2107")
+    assert lvl1_engine > lvl0_engine
+    msg_part = economy_v1.buy_upgrade(p, "lada_2107", "engine")
+    assert economy_v1.fmt_money(lvl1_engine) in msg_part
+
+
+def test_part_costs_vary():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    ecu_cost = economy_v1.upgrade_cost(price, 0, "ecu", "lada_2107")
+    engine_cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    intake_cost = economy_v1.upgrade_cost(price, 0, "intake", "lada_2107")
+    exhaust_cost = economy_v1.upgrade_cost(price, 0, "exhaust", "lada_2107")
+    assert ecu_cost < engine_cost
+    assert intake_cost > exhaust_cost
+
+
+def test_car_specific_multiplier_overrides_default():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    default_ecu = economy_v1.upgrade_cost(price, 0, "ecu")
+    lada_ecu = economy_v1.upgrade_cost(price, 0, "ecu", "lada_2107")
+    lvl_mult = economy_v1.UPGRADE_LEVEL_COST_MULTS[0]
+    mult = economy_v1._car_upgrade_mults("lada_2107").get("ecu", 1.0)
+    expected = economy_v1.round_price(price * economy_v1.UPGRADE_BASE_COST_MULT * lvl_mult * mult)
+    assert lada_ecu == expected
+    assert lada_ecu < default_ecu
+
+
+def test_prices_are_rounded():
+    cat = economy_v1.list_catalog()
+    price = cat["cars"]["lada_2107"]["price"]
+    assert price % 10 == 0
+    cost = economy_v1.upgrade_cost(price, 0, "engine", "lada_2107")
+    assert cost % 10 == 0
+    # ensure half values round upwards
+    assert economy_v1.round_price(65) == 70
+    assert economy_v1.round_price(64) == 60
+
+
+def test_mass_tradeoffs():
+    p = economy_v1.Player(user_id="5", name="T", garage=["lada_2107"])
+    base = economy_v1.car_stats(p, "lada_2107")
+    economy_v1.buy_upgrade(p, "lada_2107", "custom")
+    custom_stats = economy_v1.car_stats(p, "lada_2107")
+    economy_v1.buy_upgrade(p, "lada_2107", "turbo")
+    turbo_stats = economy_v1.car_stats(p, "lada_2107")
+    assert turbo_stats["mass"] > custom_stats["mass"]
+    assert turbo_stats["mass"] < base["mass"]
+    economy_v1.buy_upgrade(p, "lada_2107", "exhaust")
+    exhaust_stats = economy_v1.car_stats(p, "lada_2107")
+    assert exhaust_stats["mass"] < turbo_stats["mass"]
+


### PR DESCRIPTION
## Summary
- remove part synergy and introduce a bonus when completing an entire upgrade level
- lower base upgrade cost multiplier and tune car-specific multipliers using real-world pricing
- add regression test for level completion bonuses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689d2c0eaaa4832e91fee2f089b42f74